### PR TITLE
[fix]: Pagination fix

### DIFF
--- a/src/contexts/LaunchProvider.js
+++ b/src/contexts/LaunchProvider.js
@@ -33,6 +33,7 @@ const reducer = (state, action) => {
       return {
         ...state,
         launchesPerPage: action.launchesPerPage,
+        paginationPage:0,
       }
 
     case 'changeLaunchSort':


### PR DESCRIPTION
Temporarily fixes the issue of non-valid results when cards/page changes.

This resets the current page to 0 with the cards/page is changed